### PR TITLE
Add robots.txt block-all policy

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,6 @@
+# robots.txt
+# Prevent all crawlers from indexing the site.
+# This includes generic bots such as GPT/LLM crawlers.
+
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Add robots.txt to prevent site indexing by all crawlers, including GPT/LLM bots.